### PR TITLE
Semigroup-Monoid proposal compatibility

### DIFF
--- a/ignore.cabal
+++ b/ignore.cabal
@@ -30,7 +30,7 @@ library
                        Ignore.VCS.Mercurial
                        Ignore.VCS.Darcs
   build-depends:
-                       base >= 4 && < 5,
+                       base >= 4.8 && < 5,
                        path >= 0.5.1,
                        Glob >=0.7,
                        text >=1.2.0.4,

--- a/src/Ignore/Types.hs
+++ b/src/Ignore/Types.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE CPP #-}
 module Ignore.Types where
 
-#if MIN_VERSION_base(4,8,0)
-#else
-import Data.Monoid
-#endif
+import Data.Semigroup as Sem
 import Path
 import qualified Data.Text as T
 
@@ -27,7 +24,9 @@ data IgnoreFile
 newtype FileIgnoredChecker
     = FileIgnoredChecker { runFileIgnoredChecker :: FilePath -> Bool }
 
+instance Semigroup FileIgnoredChecker where
+    FileIgnoredChecker a <> FileIgnoredChecker b =
+        FileIgnoredChecker $ \fp -> a fp || b fp
+
 instance Monoid FileIgnoredChecker where
     mempty = FileIgnoredChecker $ const False
-    mappend (FileIgnoredChecker a) (FileIgnoredChecker b) =
-        FileIgnoredChecker $ \fp -> a fp || b fp

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-3.0
+resolver: lts-12.18


### PR DESCRIPTION
This PR creates Semigroup instances for Monoid instances for compatibility with GHC 8.4.

It removes the CPP and that increases the base lower bound to 4.8 as suggested in: 
https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid

base-4.8 is released with GHC 7.10 on April 2015 and I think it is reasonable to drop
supporting older versions.